### PR TITLE
[#3] Set default value for disabling auto response to true and update…

### DIFF
--- a/controllers/single_page/dashboard/system/mail/form_response.php
+++ b/controllers/single_page/dashboard/system/mail/form_response.php
@@ -60,7 +60,7 @@ class FormResponse extends DashboardPageController
             $this->set('templateHtml', LinkAbstractor::translateFromEditMode($service->getTemplateHtml(true)));
             $this->set('templateBody', $service->getTemplateBody(true));
             $this->set('sendToLoggedUser', (bool) $service->getConfig('send_to_logged_user'));
-            $this->set('disableAutoResponse', (bool) $service->getConfig('disable_auto_response'));
+            $this->set('disableAutoResponse', (bool) $service->getConfig('disable_auto_response', true));
 
             $this->set('keys', $service->getAttributeKeys());
 

--- a/single_pages/dashboard/system/mail/form_response/form.php
+++ b/single_pages/dashboard/system/mail/form_response/form.php
@@ -16,7 +16,7 @@ $templateSubject = $templateSubject ?? '';
 $templateHtml = $templateHtml ?? '';
 $templateBody = $templateBody ?? '';
 $sendToLoggedUser = $sendToLoggedUser ?? false;
-$disableAutoResponse = $disableAutoResponse ?? false;
+$disableAutoResponse = $disableAutoResponse ?? true;
 
 /** @var \Concrete\Core\Attribute\AttributeKeyInterface[] $keys */
 $keys = $keys ?? [];

--- a/src/Express/Service/ExpressFormService.php
+++ b/src/Express/Service/ExpressFormService.php
@@ -114,9 +114,9 @@ class ExpressFormService implements ApplicationAwareInterface
         return $email;
     }
 
-    public function getConfig(string $key)
+    public function getConfig(string $key, $default = '')
     {
-        return $this->config->get('forms.' . $this->getEntity()->getHandle() . '.' . $key, '');
+        return $this->config->get('forms.' . $this->getEntity()->getHandle() . '.' . $key, $default);
     }
 
     public function setConfig(string $key, $value)


### PR DESCRIPTION
### Summary of Changes

- ExpressFormService: Updated the getConfig method to support an optional $default parameter, allowing for more flexible configuration retrieval.

- FormResponse (Controller): Set the default value of disableAutoResponse to true when no saved configuration is found, ensuring the setting is enabled by default in the Dashboard.

- form.php (View): Set the default value of disableAutoResponse to true 